### PR TITLE
Added more metrics to Eval Tab

### DIFF
--- a/MAAS-SFRThelper/App.config
+++ b/MAAS-SFRThelper/App.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
@@ -20,8 +20,8 @@
 				<bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="OxyPlot" publicKeyToken="638079a8f0bd61e9" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-2.1.2.0" newVersion="2.1.2.0"/>
+				<assemblyIdentity name="OxyPlot" publicKeyToken="638079a8f0bd61e9" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-2.1.2.0" newVersion="2.1.2.0" />
 			</dependentAssembly>
 		</assemblyBinding>
 	</runtime>

--- a/MAAS-SFRThelper/MAAS-SFRThelper.csproj
+++ b/MAAS-SFRThelper/MAAS-SFRThelper.csproj
@@ -8,7 +8,7 @@
     <OutputType>library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>MAAS_SFRThelper</RootNamespace>
-    <AssemblyName>MAAS-SFRThelper.esapi</AssemblyName>
+    <AssemblyName>MAAS-SFRThelper2.esapi</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <TargetFrameworkProfile />

--- a/MAAS-SFRThelper/MAAS-SFRThelper.csproj
+++ b/MAAS-SFRThelper/MAAS-SFRThelper.csproj
@@ -8,7 +8,7 @@
     <OutputType>library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>MAAS_SFRThelper</RootNamespace>
-    <AssemblyName>MAAS-SFRThelper2.esapi</AssemblyName>
+    <AssemblyName>MAAS-SFRThelper.esapi</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <TargetFrameworkProfile />

--- a/MAAS-SFRThelper/ViewModels/EvaluationViewModel.cs
+++ b/MAAS-SFRThelper/ViewModels/EvaluationViewModel.cs
@@ -1454,17 +1454,59 @@ namespace MAAS_SFRThelper.ViewModels
                     value = Math.Round(d50Value.Dose, 3).ToString()
                 });
 
+                // d20
+                var d20Value = plan.GetDoseAtVolume(structureForEval, 20, absoluteVolume, absoluteDoseValue);
+                AllMetrics.Add(new MetricData
+                {
+                    metric = "Dose Covering 20% of Target (D20) (Gy)",
+                    value = Math.Round(d20Value.Dose, 3).ToString()
+                });
+                
+                // d10
+                var d10Value = plan.GetDoseAtVolume(structureForEval, 50, absoluteVolume, absoluteDoseValue);
+                AllMetrics.Add(new MetricData
+                {
+                    metric = "Dose Covering 10% of Target (D10) (Gy)",
+                    value = Math.Round(d10Value.Dose, 3).ToString()
+                });
+                
+                // d5
+                var d5Value= plan.GetDoseAtVolume(structureForEval, 50, absoluteVolume, absoluteDoseValue);
+                AllMetrics.Add(new MetricData
+                {
+                    metric = "Dose Covering 5% of Target (D5) (Gy)",
+                    value = Math.Round(d5Value.Dose, 3).ToString()
+                });
 
+                // d95/d5
+                AllMetrics.Add(new MetricData
+                {
+                    metric = "D95/D5",
+                    value = Math.Round(d95Value.Dose/d5Value.Dose, 3).ToString()
+                });
 
+                // d10/d90
+                AllMetrics.Add(new MetricData
+                {
+                    metric = "D10/D90",
+                    value = Math.Round(d10Value.Dose/d90Value.Dose, 3).ToString()
+                });
+
+                // High dose core number density
+                AllMetrics.Add(new MetricData
+                {
+                    metric = "High Dose Core Number Density (HCND)",
+                    value = Math.Round(d10Value.Dose / d90Value.Dose, 3).ToString()
+                });
 
             }
             catch (Exception ex)
             {
-                OutputLog += $"Error calculating D95: {ex.Message}\n";
+                OutputLog += $"Error calculating Dose: {ex.Message}\n";
                 AllMetrics.Add(new MetricData
                 {
-                    metric = "Dose Covering 95% of Target (D95) (Gy)",
-                    value = "Error - Unable to calculate"
+                    metric = "Dose Covering x% of Target (Dx) (Gy)", // with the added doses I'm not sure how to report this best
+                    value = "Error - Unable to calculate Dose/DVH"
                 });
             }
 

--- a/MAAS-SFRThelper/ViewModels/EvaluationViewModel.cs
+++ b/MAAS-SFRThelper/ViewModels/EvaluationViewModel.cs
@@ -1440,6 +1440,23 @@ namespace MAAS_SFRThelper.ViewModels
                     metric = "Dose Covering 95% of Target (D95) (Gy)",
                     value = Math.Round(d95Value.Dose, 3).ToString()
                 });
+                var d90Value = plan.GetDoseAtVolume(structureForEval, 90, absoluteVolume, absoluteDoseValue);
+                AllMetrics.Add(new MetricData
+                {
+                    metric = "Dose Covering 90% of Target (D95) (Gy)",
+                    value = Math.Round(d90Value.Dose, 3).ToString()
+                });
+
+                var d50Value = plan.GetDoseAtVolume(structureForEval, 50, absoluteVolume, absoluteDoseValue);
+                AllMetrics.Add(new MetricData
+                {
+                    metric = "Dose Covering 50% of Target (D50) (Gy)",
+                    value = Math.Round(d50Value.Dose, 3).ToString()
+                });
+
+
+
+
             }
             catch (Exception ex)
             {

--- a/MAAS-SFRThelper/ViewModels/EvaluationViewModel.cs
+++ b/MAAS-SFRThelper/ViewModels/EvaluationViewModel.cs
@@ -1407,10 +1407,11 @@ namespace MAAS_SFRThelper.ViewModels
             });
 
             // Number of vertices (separate parts)
+            var numVertices = ptvAll.GetNumberOfSeparateParts();
             AllMetrics.Add(new MetricData
             {
                 metric = "Number of Vertices",
-                value = ptvAll.GetNumberOfSeparateParts().ToString()
+                value = numVertices.ToString()
             });
 
             // Volume of vertices
@@ -1496,7 +1497,7 @@ namespace MAAS_SFRThelper.ViewModels
                 AllMetrics.Add(new MetricData
                 {
                     metric = "High Dose Core Number Density (HCND)",
-                    value = Math.Round(d10Value.Dose / d90Value.Dose, 3).ToString()
+                    value = Math.Round((numVertices * 100 / structureForEval.Volume), 3).ToString()
                 });
 
             }

--- a/MAAS-SFRThelper/packages.config
+++ b/MAAS-SFRThelper/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NLog" version="5.2.4" targetFramework="net48" />
+  <package id="NLog" version="5.2.4" targetFramework="net461" />
   <package id="OxyPlot.Core" version="2.1.2" targetFramework="net461" />
   <package id="OxyPlot.Wpf" version="2.0.0" targetFramework="net461" />
   <package id="OxyPlot.Wpf.Shared" version="2.1.2" targetFramework="net461" />


### PR DESCRIPTION
Added some more doses + high dose core number density (which, I have been told, is becoming a relevant parameter for SFRT planning) to the eval tab. 

Feel free to ignore the package/properties changes [only ViewModel changes are relevant]